### PR TITLE
fix: ensure pagination in GitLab scheduler API

### DIFF
--- a/check-plugins/check_gitlab_scheduler/check_gitlab_scheduler.py
+++ b/check-plugins/check_gitlab_scheduler/check_gitlab_scheduler.py
@@ -61,6 +61,7 @@ def check_gitlab_scheduler(
         + "/api/v4/projects/"
         + project_id
         + "/pipeline_schedules"
+        + "?per_page=1000"
     )
     try:
         r = client.get(url)


### PR DESCRIPTION
fix: ensure pagination in GitLab scheduler API call by adding per_page parameter