### PR TITLE
feature: script to check specific job names

### DIFF
--- a/check-plugins/check_gitlab_jobs/README.md
+++ b/check-plugins/check_gitlab_jobs/README.md
@@ -1,0 +1,85 @@
+# Check GitLab Jobs
+
+This script checks the status of a specific GitLab CI/CD job. It retrieves the last 100 jobs from a GitLab project and monitors the status of the most recent job matching the provided job name.
+
+## Requirements
+
+Install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+./check_gitlab_jobs.py -u <GITLAB_URL> -p <PROJECT_ID> -t <TOKEN> -j <JOB_NAME>
+```
+
+### Example
+
+```bash
+./check_gitlab_jobs.py -u https://gitlab.example.com -p 123 -t glpat-xxxxxxxxxxxx -j deploy_qa
+```
+
+## Parameters
+
+| Parameter | Short | Description | Required |
+|-----------|-------|-------------|----------|
+| `--gitlab_url` | `-u` | GitLab instance URL (e.g., https://gitlab.example.com) | Yes |
+| `--projectid` | `-p` | GitLab project ID | Yes |
+| `--token` | `-t` | GitLab private token with API access | Yes |
+| `--jobname` | `-j` | Name of the job to check (exact match) | Yes |
+
+## Exit Codes
+
+| Code | Status | Description |
+|------|--------|-------------|
+| 0 | OK | Job status is 'success' or job not found in last 100 jobs |
+| 1 | WARNING | Job status is 'running' or 'pending' |
+| 2 | CRITICAL | Job status is 'failed', 'canceled', 'skipped', or any other non-success status |
+
+## Examples
+
+### Success Status
+
+```
+OK - Job: deploy_qa, Job-ID: 12345, Status: success, URL: https://gitlab.example.com/project/repo/-/jobs/12345
+```
+
+**Exit Code:** 0
+
+### Running/Pending Status
+
+```
+WARNING - Job: deploy_qa, Job-ID: 12346, Status: running, URL: https://gitlab.example.com/project/repo/-/jobs/12346
+```
+
+**Exit Code:** 1
+
+### Failed Status
+
+```
+CRITICAL - Job: deploy_qa, Job-ID: 12347, Status: failed, URL: https://gitlab.example.com/project/repo/-/jobs/12347
+```
+
+**Exit Code:** 2
+
+### Job Not Found
+
+```
+OK - Job 'deploy_qa' not found in last 100 jobs
+```
+
+**Exit Code:** 0
+
+## Notes
+
+- The script retrieves the last 100 jobs ordered by ID (most recent first)
+- Only the most recent job matching the exact job name is checked
+- If a job is not found in the last 100 jobs, the check returns OK (useful for jobs that don't run regularly)
+- The script uses exact name matching, not substring matching
+
+## Authors
+
+- Sebastian Wolschke

--- a/check-plugins/check_gitlab_jobs/check_gitlab_jobs.py
+++ b/check-plugins/check_gitlab_jobs/check_gitlab_jobs.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 *-*
+
+"""
+Copyright 2025 Deutsche Telekom MMS GmbH
+Maintainer: Sebastian Wolschke
+"""
+
+import sys
+import argparse
+from argparse import RawDescriptionHelpFormatter
+import requests
+
+
+def check_gitlab_jobs(
+    gitlab_url: str,
+    project_id: str,
+    token: str,
+    job_name: str,
+) -> None:
+    """Checks the status of a specific GitLab job"""
+    client = requests.Session()
+    client.headers.update({'PRIVATE-TOKEN': token})
+
+    url = (
+        f"{gitlab_url}/api/v4/projects/{project_id}/jobs"
+        f"?per_page=100&order_by=id&sort=desc"
+    )
+
+    try:
+        r = client.get(url, timeout=60)
+        r.raise_for_status()
+    except requests.exceptions.ConnectionError as err:
+        print(f"CRITICAL - Unable to connect to GitLab URL '{gitlab_url}': {err}")
+        sys.exit(2)
+    except requests.exceptions.Timeout as err:
+        print(f"CRITICAL - Connection timeout while reaching GitLab URL '{gitlab_url}': {err}")
+        sys.exit(2)
+    except requests.exceptions.HTTPError as err:
+        if r.status_code == 401:
+            print(f"CRITICAL - Access denied: Invalid or unauthorized token for GitLab URL '{gitlab_url}'")
+        elif r.status_code == 404:
+            print(f"CRITICAL - Project not found: Project ID '{project_id}' does not exist or you don't have access to it")
+        else:
+            print(f"CRITICAL - HTTP Error: {err}")
+        sys.exit(2)
+    except requests.exceptions.JSONDecodeError as err:
+        print(f"CRITICAL - unable to decode JSON from the HTTP Response: {err}")
+        sys.exit(2)
+
+    jobs = r.json()
+
+    # Find the first (most recent) job matching the job name
+    for job in jobs:
+        if job['name'] == job_name:
+            job_id = job['id']
+            status = job['status']
+            web_url = job['web_url']
+
+            if status == 'success':
+                print(
+                    f"OK - Job: {job_name}, Job-ID: {job_id}, "
+                    f"Status: {status}, URL: {web_url}"
+                )
+                sys.exit(0)
+            elif status in ['running', 'pending']:
+                print(
+                    f"WARNING - Job: {job_name}, Job-ID: {job_id}, "
+                    f"Status: {status}, URL: {web_url}"
+                )
+                sys.exit(1)
+            else:
+                print(
+                    f"CRITICAL - Job: {job_name}, Job-ID: {job_id}, "
+                    f"Status: {status}, URL: {web_url}"
+                )
+                sys.exit(2)
+
+    # Job not found in last 100 jobs
+    print(f"OK - Job '{job_name}' not found in last 100 jobs")
+    sys.exit(0)
+
+
+def main() -> None:
+    """Entrypoint"""
+    parser = argparse.ArgumentParser(
+        prog="Check Gitlab Jobs",
+        description="""This script checks the status of a specific GitLab job.
+It retrieves the last 100 jobs from a project and checks the status of the
+most recent job matching the provided job name. The check returns OK if the
+job status is 'success' or if the job is not found, WARNING if the job is
+'running' or 'pending', and CRITICAL for any other status (failed, canceled,
+skipped, etc.).""",
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("-u", "--gitlab_url", dest="gitlab_url", required=True)
+    parser.add_argument("-p", "--projectid", dest="project_id", required=True)
+    parser.add_argument("-t", "--token", dest="token", required=True)
+    parser.add_argument(
+        "-j",
+        "--jobname",
+        dest="job_name",
+        required=True,
+        help="The name of the job to check"
+    )
+    args = parser.parse_args()
+
+    check_gitlab_jobs(
+        args.gitlab_url,
+        args.project_id,
+        args.token,
+        args.job_name,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/check-plugins/check_gitlab_jobs/requirements.txt
+++ b/check-plugins/check_gitlab_jobs/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
The script checks the status of a specific GitLab CI/CD job by name.
Useful for monitoring automatically triggered jobs, e.g., deployments via push.
